### PR TITLE
wr-kernel: remove initramfs-install

### DIFF
--- a/recipes-kernel/linux/kernel-initramfs-image.bb
+++ b/recipes-kernel/linux/kernel-initramfs-image.bb
@@ -32,6 +32,7 @@ FILES_${PN} = "/boot/*"
 ALLOW_EMPTY_${PN} = "1"
 INITRAMFS_BASE_NAME = "${KERNEL_IMAGETYPE}-initramfs-${PV}-${PR}-${MACHINE}-${DATETIME}"
 INITRAMFS_BASE_NAME[vardepsexclude] = "DATETIME"
+INITRAMFS_EXT_NAME = "-${@base_read_file('${STAGING_KERNEL_BUILDDIR}/kernel-abiversion')}"
 
 python __anonymous () {
     image = d.getVar('INITRAMFS_IMAGE', True)
@@ -48,14 +49,14 @@ do_install() {
 		for img in cpio.gz cpio.lzo cpio.lzma cpio.xz; do
 			if [ -e "${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.$img" ]; then
 				install -d ${D}/boot
-				install -m 0644 ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.$img ${D}/boot/${INITRAMFS_IMAGE}-${MACHINE}.$img
+				install -m 0644 ${DEPLOY_DIR_IMAGE}/${INITRAMFS_IMAGE}-${MACHINE}.$img ${D}/boot/${INITRAMFS_IMAGE}${INITRAMFS_EXT_NAME}.$img
 				break
 			fi
 		done
 	elif [ "x${INSTALL_BUNDLE}" = "x1" ] ; then
 		if [ -e "${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin" ]; then
 			install -d ${D}/boot
-			install -m 0644 ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin ${D}/boot/${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin
+			install -m 0644 ${DEPLOY_DIR_IMAGE}/${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin ${D}/boot/${KERNEL_IMAGETYPE}-initramfs${INITRAMFS_EXT_NAME}
 		fi
 	fi
 }
@@ -65,14 +66,14 @@ PACKAGE_ARCH = "${MACHINE_ARCH}"
 pkg_postinst_${PN} () {
 #!/bin/sh
     if [ "x${INSTALL_BUNDLE}" = "x1" ] ; then
-        update-alternatives --install /boot/${KERNEL_IMAGETYPE} ${KERNEL_IMAGETYPE} /boot/${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin 50101 || true
+        update-alternatives --install /boot/${KERNEL_IMAGETYPE} ${KERNEL_IMAGETYPE} /boot/${KERNEL_IMAGETYPE}-initramfs${INITRAMFS_EXT_NAME} 50101 || true
     fi
 }
 
 pkg_prerm_${PN} () {
 #!/bin/sh
     if [ "x${INSTALL_BUNDLE}" = "x1" ] ; then
-        update-alternatives --remove ${KERNEL_IMAGETYPE} ${KERNEL_IMAGETYPE}-initramfs-${MACHINE}.bin || true
+        update-alternatives --remove ${KERNEL_IMAGETYPE} ${KERNEL_IMAGETYPE}-initramfs${INITRAMFS_EXT_NAME} || true
     fi
 }
 

--- a/recipes-kernel/linux/kernel-initramfs-image.bb
+++ b/recipes-kernel/linux/kernel-initramfs-image.bb
@@ -24,11 +24,9 @@ do_unpack[depends] += "virtual/kernel:do_deploy"
 B = "${WORKDIR}/${BPN}-${PV}"
 
 INSTALL_INITRAMFS = "${@'1' if d.getVar('INITRAMFS_IMAGE', True) and \
-                               d.getVar('INITRAMFS_IMAGE_BUNDLE', True) != '1' and \
-                               d.getVar('INITRAMFS_IMAGE_INSTALL', True) == '1' else '0'}"
+                               d.getVar('INITRAMFS_IMAGE_BUNDLE', True) != '1' else '0'}"
 INSTALL_BUNDLE    = "${@'1' if d.getVar('INITRAMFS_IMAGE', True) and \
-                               d.getVar('INITRAMFS_IMAGE_BUNDLE', True) == '1' and \
-                               d.getVar('INITRAMFS_IMAGE_INSTALL', True) == '1' else '0'}"
+                               d.getVar('INITRAMFS_IMAGE_BUNDLE', True) == '1' else '0'}"
 
 FILES_${PN} = "/boot/*"
 ALLOW_EMPTY_${PN} = "1"

--- a/recipes-kernel/linux/linux-windriver.inc
+++ b/recipes-kernel/linux/linux-windriver.inc
@@ -147,8 +147,7 @@ addtask extract_kernel_output after do_compile_kernelmodules
 
 python __anonymous () {
     if d.getVar('INITRAMFS_IMAGE', True) and \
-       d.getVar('INITRAMFS_IMAGE_BUNDLE', True) == '1' and \
-       d.getVar('INITRAMFS_IMAGE_INSTALL', True) == '1':
+       d.getVar('INITRAMFS_IMAGE_BUNDLE', True) == '1':
 
         tfmake = d.getVar('KERNEL_IMAGETYPE_FOR_MAKE', True) or ""
 

--- a/templates/feature/initramfs-install/README
+++ b/templates/feature/initramfs-install/README
@@ -1,7 +1,0 @@
-
-                                initramfs-install
-                               ----------------------
-
-Configure the build to create an initramfs image which will be integrated with
-the kernel image and install into rootfs. For additional information, please review the initramfs.txt
-document found in the layers/wr-kernel/Documentation directory.

--- a/templates/feature/initramfs-install/image.inc
+++ b/templates/feature/initramfs-install/image.inc
@@ -1,1 +1,0 @@
-IMAGE_INSTALL += " kernel-initramfs-image"

--- a/templates/feature/initramfs-install/template.conf
+++ b/templates/feature/initramfs-install/template.conf
@@ -1,3 +1,0 @@
-# Add initramfs image creation which will be integrated in the kernel image
-INITRAMFS_IMAGE_INSTALL = "1"
-INITRAMFS_IMAGE ?= "wrlinux-image-initramfs"


### PR DESCRIPTION
This feature is not necessary because the bundled kernel will be
installed instead of the normal kernel image as long as configured.

Signed-off-by: Lans Zhang <jia.zhang@windriver.com>